### PR TITLE
Set Accessory Information during Add

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ output: the websocket-client sends a message to the homebridge-websocket.
 {"topic": "add", "payload": {"name": "flex_lamp", "service": "Switch"}}
 ```
 
+or with the additional accessory informations
+```sh
+{"topic": "add", "payload": {"name": "flex_lamp", "service": "Switch", "manufacturer": "lamp_manu", "model": "flex_007", "serialnumber": "4711", "firmwarerevision": "1.0.0"}}
+```
+
 After the new accessory is added homebridge-websocket sends an acknowledge message:
 
 ```sh


### PR DESCRIPTION
This adds support for setting the manufacturer, model, etc information during the add process. This information can either be passed in via the add request or will be set to defaults. (Code is based on homebridge-mqtt code).  Hope to be able to update this information via a separate request object, but based on the original PR, this may be useless.