### PR TITLE
Update WebSocket Server to handle multiple connections.

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -5,6 +5,7 @@ var path = require('path');
 var Utils = require('./utils.js').Utils;
 var port, plugin_name, accessories, Characteristic, addAccessory, removeAccessory, getAccessories;
 var latest, get_timeout, set_timeout, pre_name, pre_c;
+var connections = [];
 
 var WebSocketServer = require('ws').Server,
   http = require('http'),
@@ -61,6 +62,8 @@ Websocket.prototype.startServer = function() {
     
     set_timeout = setTimeout(function() {
       this.log("client ip %s connected", req.connection.remoteAddress);
+      connections.push(this.ws);
+      this.log("client added to connections array");
     }.bind(this), 500);
           
   }.bind(this));
@@ -246,13 +249,14 @@ Websocket.prototype.sendAck = function (ack, message) {
 
 Websocket.prototype.sendData = function(data) {
 
-  if (typeof(this.ws) !== "undefined" && this.ws.OPEN) {
-    var j_data = JSON.stringify(data);
-    
-    this.log.debug("sendData %s", JSON.stringify(data)); // JSON.stringify(data, null, 2));
-    
-    this.ws.send(j_data, function ack(error) {
-      if (error) this.log("sendData %s", error);
-    }.bind(this));
+  var j_data = JSON.stringify(data);
+  this.log.debug("sendData %s", JSON.stringify(data)); // JSON.stringify(data, null, 2));
+  for(var i = 0; i < connections.length; i++) {
+    if (typeof(connections[i]) !== "undefined" && connections[i].OPEN) {
+        connections[i].send(j_data,function ack(error) {
+          if (error) this.log("sendData %s", error);
+        }.bind(this));
+    }
   }
 }
+


### PR DESCRIPTION
This pull request is incomplete (due to my inexperience in js...), but hoping someone else can help finish it off. The code change works to handle to multiple connections, what is missing is removing a disconnected session from the connections array. In addition, I am not sure why, but the sendData function still tries to send data to a closed connection and logs an error.